### PR TITLE
[Technical Support] LPS-73428 Related Asset Browser Wrong encoding for site names with ap…

### DIFF
--- a/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -338,8 +338,7 @@ public class AssetBrowserDisplayContext {
 
 		Group group = GroupLocalServiceUtil.fetchGroup(getGroupId());
 
-		return HtmlUtil.escape(
-			group.getDescriptiveName(themeDisplay.getLocale()));
+		return group.getDescriptiveName(themeDisplay.getLocale());
 	}
 
 	public String getOrderByCol() {


### PR DESCRIPTION
…ostrophe

Hi Dustin,

We have a common "double escaped" issue. Omar's solution will delete escaping from server side logic.

Thanks in advance,
 Zsaga